### PR TITLE
Dodana možnost uporabe s Python <= 3.5 in knjižnico pysha3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bootstrap-4.1.1/* linguist-vendored

--- a/aplikacija.py
+++ b/aplikacija.py
@@ -7,7 +7,10 @@ import auth_public as auth
 import psycopg2, psycopg2.extensions, psycopg2.extras
 from operator import itemgetter
 
-import hashlib
+try:
+    import sha3 as hashlib
+except ModuleNotFoundError:
+    import hashlib
 
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)  # se znebimo problemov s šumniki
 


### PR DESCRIPTION
Ker mi s Python 3.6 ne deluje knjižnica `psycopg2`, v Python 3.5 pa knjižnica `hashlib` še ne podpira zgoščevalne funkcije SHA3, je tukaj popravek, da je vajino aplikacijo mogoče uporabljati tudi s Python 3.5 in nameščeno knjižnico `pysha3`. Prosim vaju torej, da sprejmeta tale pull request.

Drugače pa imam samo eno pripombo: pri spreminjanju podatkov profila je potrebno za kakršnokoli spremembo vsakič vnesti geslo. Lepše bi bilo, če bi obrazec dovolil spremembo hiše in spola, če so vsa polja za geslo prazna.